### PR TITLE
Update game3.js link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Introduction
 ![game3.js demo gif](doc/img/intro.gif)
 
 #### Getting Started
-www.game3js.com
+http://game3js.com
 
 [overview]: (https://docs.google.com/drawings/d/1aUSMeocqC4oyyutpTRau8Zaz0Bd4oMRcr8css3sCgcM/edit?usp=sharing)
 [overview-img]: (https://docs.google.com/drawings/d/e/2PACX-1vRzF6Ws2C2BXrQAIcSi-XWQLYrgxnEQ2-Z1xCdN2MERA12LAdxllNVqNmRh4xdBSq6LRx2KX4M-7vWW/pub?w=960&amp;h=720)


### PR DESCRIPTION
There is an issue when you click on the www.game3js.com it shows

![game3js](https://user-images.githubusercontent.com/41552663/77374678-c1cd9900-6d41-11ea-8833-32354afae037.png)

Try:

http://game3js.com and it redirects to the expected page

![game3jss](https://user-images.githubusercontent.com/41552663/77374769-fa6d7280-6d41-11ea-909e-aee6a1304f25.png)

